### PR TITLE
Create App's Domain Buttons

### DIFF
--- a/binder-web-frontend/src/pages/home/components/domain-buttons/domain-buttons.component.html
+++ b/binder-web-frontend/src/pages/home/components/domain-buttons/domain-buttons.component.html
@@ -1,0 +1,4 @@
+<div class="domain-buttons">
+  <p class="domain-buttons__button">Options</p>
+  <p class="domain-buttons__button">About</p>
+</div>

--- a/binder-web-frontend/src/pages/home/components/domain-buttons/domain-buttons.component.html
+++ b/binder-web-frontend/src/pages/home/components/domain-buttons/domain-buttons.component.html
@@ -1,4 +1,4 @@
 <div class="domain-buttons">
-  <p class="domain-buttons__button">Options</p>
-  <p class="domain-buttons__button">About</p>
+  <p class="domain-buttons__button" (click)="optionsClicked()">Options</p>
+  <p class="domain-buttons__button" (click)="aboutClicked()">About</p>
 </div>

--- a/binder-web-frontend/src/pages/home/components/domain-buttons/domain-buttons.component.scss
+++ b/binder-web-frontend/src/pages/home/components/domain-buttons/domain-buttons.component.scss
@@ -1,0 +1,17 @@
+.domain-buttons {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    font-size: 12px;
+    padding: 10px 0px;
+
+    &__button {
+        height: 15px;
+        width: fit-content;
+        margin: 0px;
+
+        &:hover {
+            cursor: pointer;
+        }
+    }
+}

--- a/binder-web-frontend/src/pages/home/components/domain-buttons/domain-buttons.component.scss
+++ b/binder-web-frontend/src/pages/home/components/domain-buttons/domain-buttons.component.scss
@@ -2,13 +2,13 @@
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
-    font-size: 12px;
-    padding: 10px 0px;
+    row-gap: 0.5rem;
+    font-size: 0.75rem;
 
     &__button {
-        height: 15px;
+        height: 0.938rem;
         width: fit-content;
-        margin: 0px;
+        margin: 0;
 
         &:hover {
             cursor: pointer;

--- a/binder-web-frontend/src/pages/home/components/domain-buttons/domain-buttons.component.ts
+++ b/binder-web-frontend/src/pages/home/components/domain-buttons/domain-buttons.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'domain-buttons',
+  templateUrl: './domain-buttons.component.html',
+  styleUrls: ['./domain-buttons.component.scss']
+})
+export class DomainButtonsComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/binder-web-frontend/src/pages/home/components/domain-buttons/domain-buttons.component.ts
+++ b/binder-web-frontend/src/pages/home/components/domain-buttons/domain-buttons.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 
 @Component({
   selector: 'domain-buttons',
@@ -6,10 +6,18 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./domain-buttons.component.scss']
 })
 export class DomainButtonsComponent implements OnInit {
+  @Output() optionsClickedEvent: EventEmitter<HTMLParagraphElement> = new EventEmitter();
+  @Output() aboutClickedEvent: EventEmitter<HTMLParagraphElement> = new EventEmitter();
 
   constructor() { }
 
-  ngOnInit() {
+  ngOnInit() { }
+
+  optionsClicked() {
+    this.optionsClickedEvent.emit();
   }
 
+  aboutClicked() {
+    this.aboutClickedEvent.emit();
+  }
 }

--- a/binder-web-frontend/src/pages/home/home.component.html
+++ b/binder-web-frontend/src/pages/home/home.component.html
@@ -2,4 +2,5 @@
   <navbar></navbar>
   <tables-list></tables-list>
   <table-view></table-view>
+  <domain-buttons></domain-buttons>
 </div>

--- a/binder-web-frontend/src/pages/pages.module.ts
+++ b/binder-web-frontend/src/pages/pages.module.ts
@@ -7,10 +7,11 @@ import { TablesListComponent } from './home/components/tables-list/tables-list.c
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatTableModule } from '@angular/material/table';
 import { TableViewComponent } from './home/components/table-view/table-view.component';
+import { DomainButtonsComponent } from './home/components/domain-buttons/domain-buttons.component';
 
 @NgModule({
   imports: [CommonModule, MatDividerModule, MatExpansionModule, MatTableModule],
-  declarations: [HomeComponent, NavbarComponent, TablesListComponent, TableViewComponent],
+  declarations: [HomeComponent, NavbarComponent, TablesListComponent, TableViewComponent, DomainButtonsComponent],
   exports: [HomeComponent],
 })
 export class PagesModule {}


### PR DESCRIPTION
## Summary

Add Domain Buttons component to Web Frontend.

## Details

Component contains two clickable paragraphs: "Options" and "About".

"Options" will redirect user's viewport to options view.
"About" will display dialog with info about app.

![image](https://github.com/Strayker-Software/Binder/assets/45916090/cc59ac22-2a35-4e73-9205-0990ac0aa18b)

Target of this ticket was to create just this component, any other work is out of scope here.

## References

No external references needed.
