### PR TITLE
Change URL of OpenAPI specs in generator's command

### DIFF
--- a/binder-web-frontend/openapitools.json
+++ b/binder-web-frontend/openapitools.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.0.1"
+  }
+}

--- a/binder-web-frontend/package.json
+++ b/binder-web-frontend/package.json
@@ -8,7 +8,7 @@
     "watch": "ng build --watch --configuration development",
     "prepare-husky": "cd .. && husky install binder-web-frontend/.husky",
     "prettier": "npx prettier --write --ignore-unknown src/",
-    "gen": "openapi-generator-cli generate -g typescript-angular -i https://localhost:7183/swagger/v1/swagger.json -o ./src/api"
+    "gen": "openapi-generator-cli generate -g typescript-angular -i http://localhost:5246/swagger/v1/swagger.json -o ./src/api"
   },  
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary

Make OpenAPI Generator run on HTTP URL of Web Backend.

## Details

Generate OpenAPI Generator's config.

## References

No external references needed.
