### PR TITLE
fix(webfrontend): Fix Dark Mode for navbar

### DIFF
--- a/binder-web-frontend/src/pages/home/components/navbar/navbar.component.html
+++ b/binder-web-frontend/src/pages/home/components/navbar/navbar.component.html
@@ -1,7 +1,7 @@
-<div class="navbar">
-  <button mat-button class="navbar__button">Show Completed</button>
-  <mat-divider [vertical]="true"></mat-divider>
-  <button mat-button class="navbar__button">Show/Hide Column</button>
-  <mat-divider [vertical]="true"></mat-divider>
-  <button mat-button class="navbar__button">Reset View</button>
+<div class="navbar mat-app-background">
+  <button mat-button class="navbar__button mat-app-background">Show Completed</button>
+  <mat-divider [vertical]="true" class="navbar__divider"></mat-divider>
+  <button mat-button class="navbar__button mat-app-background">Show/Hide Column</button>
+  <mat-divider [vertical]="true" class="navbar__divider"></mat-divider>
+  <button mat-button class="navbar__button mat-app-background">Reset View</button>
 </div>

--- a/binder-web-frontend/src/pages/home/components/navbar/navbar.component.scss
+++ b/binder-web-frontend/src/pages/home/components/navbar/navbar.component.scss
@@ -1,6 +1,5 @@
 .navbar {
   border-radius: 0.625rem;
-  background: #ffffff;
   box-shadow: 0px 0px 16px #00000025;
   width: 35rem;
   height: 1.2rem;
@@ -9,10 +8,13 @@
 
   &__button {
     border: transparent;
-    background-color: #ffffff;
 
     &:hover {
       cursor: pointer;
     }    
+  }
+
+  &__divider {
+    background-color: #ffffff;
   }
 }


### PR DESCRIPTION
## Summary

Fix Dark Mode for navbar component.

## Details

Navbar component changes its background and foreground colors to follow Material Design's rules of Dark Mode:

![image](https://github.com/Strayker-Software/Binder/assets/80634023/724e27d3-6abf-4649-89f9-39253af4c9cc)


## References

No external references needed.
