### PR TITLE
Prepare Contribution Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,30 @@
-# Contribution info for Binder
+# Binder Contribution Guidelines
 
-There are some ways to contribute to project:
+## First Steps
 
-- read issues labeled "help-wanted" and try to solve problem from it,
-- access "master" branch code, look for TODO tags and create code for given point of development,
-- try to imagine some feature and submit an issue about it, maybe your idea will be helpful,
+On the beginning, we would like to say thank you for your help whith this project. This means a lot for us, motivates and shows us, that we are on the right path.
 
-Also before submitting any code or issuing help, read project's code of conduct in repo's main folder!
+Depending on what you want to do in the project, there are some types of help described below. Choose one and go for it!
+
+Your first step on contribution journey should be project's Wiki. There are many usefull information to start with, also with descriptions of how was something implemented, designed, planned, etc. There's also `docs` folder in repo, where are some generated docs files and business documents.
+
+All Strayker Software Open Source projects have [Code of Conduct](/CODE_OF_CONDUCT.md) attached. When contributing, we expect you to follow everything, that is described there. Also every repository has it's own licensing terms, please read [License file](/LICENSE.md) to discover, under which terms our cooperation will follow.
+
+### New Feature Idea
+
+You've got some great idea for new functionality in this project? Great!
+
+Here is point list of what to do:
+
+- go to project's issue list and use searching and filtering to find out if something simmilar already was proposed/planned,
+- if your idea is new, than submit an issue on repo, using proper issue template and wait until someone from project management will check it out,
+- as soon as your idea is accepted, your issue will be proceeded with project's workflow,
+
+If you want to also work over your own idea, look into [Coding](#coding) section.
+
+### Bug/Error/Typo Report
+
+### Text Help (Documentation, Translation, etc.)
+
+### Coding
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,38 @@ If you want to also work over your own idea, look into [Coding](#coding) section
 
 ### Bug/Error/Typo Report
 
+__Found some security issues? Instead of this instructions, please follow project's [Security Policy](https://github.com/Strayker-Software/Binder/security/policy)__
+
+Did you found some mistake in app or text? Let us know, we will fix that!
+
+Here is point list of what to do:
+
+- go to project's issue list and use searching and filtering to find out if something simmilar already was found,
+- if your report is new, than submit an issue on repo, using proper issue template and wait until someone from project management will check it out,
+- as soon as your idea is accepted, your issue will be proceeded with project's workflow,
+
+If you want to also work over your report, look into [Coding](#coding) section.
+
 ### Text Help (Documentation, Translation, etc.)
+
+Want to translate some docs, or help creating new descriptions?
+
+Here is point list of what to do:
+
+- go to project's issue list and use searching and filtering to find out if there are some issues marked with `documentation` label,
+- if there's any free issue, write comment on it to apply, someone from project management will check your application,
+- as soon as docs changes were approved by project management, you are free to go,
+
+Check out [Wiki](https://github.com/Strayker-Software/Binder/wiki) on how to work over documentation tasks.
 
 ### Coding
 
+So you want to code something up? Ok, let's go!
+
+Here is point list of what to do:
+
+- go to project's issue list and use searching and filtering to find out if there are some issues, that are not started yet, laying in "Ready for Development" state,
+- if there's any free issue, write comment on it to apply, someone from project management will check your application,
+- as soon as your work was added to work scope by project management, you can start coding,
+
+Find out how to write code in compliance with project's coding guidelines by looking into [Wiki](https://github.com/Strayker-Software/Binder/wiki).


### PR DESCRIPTION
## Summary

Add new version of Contribution Guidelines to project's repo.

## Details

Describes how external GitHub user can:

- propose new feature,
- report bugs/errors/typos,
- help with text writting,
- code up some app's logic,

## References

No external references needed.
