### PR TITLE
fix(webfrontend): Make button's labels unselectable

### DIFF
--- a/binder-web-frontend/src/pages/home/components/domain-buttons/domain-buttons.component.scss
+++ b/binder-web-frontend/src/pages/home/components/domain-buttons/domain-buttons.component.scss
@@ -4,6 +4,7 @@
   justify-content: flex-start;
   row-gap: 0.5rem;
   font-size: 0.75rem;
+  user-select: none;
 
   &__button {
     height: 0.938rem;

--- a/binder-web-frontend/src/pages/home/components/navbar/navbar.component.scss
+++ b/binder-web-frontend/src/pages/home/components/navbar/navbar.component.scss
@@ -5,6 +5,7 @@
   height: 1.2rem;
   display: flex;
   justify-content: space-evenly;
+  user-select: none;
 
   &__button {
     border: transparent;

--- a/binder-web-frontend/src/pages/home/components/tables-list/tables-list.component.scss
+++ b/binder-web-frontend/src/pages/home/components/tables-list/tables-list.component.scss
@@ -1,4 +1,6 @@
 .tables {
+  user-select: none;
+
   &__accordion {
     &-panel {
       &-header {


### PR DESCRIPTION
## Summary

Make button's labels unselectable.

## Details

After this change all button labels are non selectable. 

## References

No external references needed.
