### PR TITLE
fix(webfrontend): Make table list elements clickable

### DIFF
--- a/binder-web-frontend/src/pages/home/components/tables-list/tables-list.component.html
+++ b/binder-web-frontend/src/pages/home/components/tables-list/tables-list.component.html
@@ -5,8 +5,8 @@
         <mat-panel-title> {{ 'tablesList.tables' | transloco }} </mat-panel-title>
       </mat-expansion-panel-header>
       <div class="tables__accordion-panel-content">
-        <p>{{ 'tablesList.toDoList' | transloco }}</p>
-        <p>{{ 'tablesList.customList' | transloco }}</p>
+        <p (click)="onToDoListClicked()">{{ 'tablesList.toDoList' | transloco }}</p>
+        <p (click)="onCustomListClicked()">{{ 'tablesList.customList' | transloco }}</p>
       </div>
     </mat-expansion-panel>
   </mat-accordion>

--- a/binder-web-frontend/src/pages/home/components/tables-list/tables-list.component.scss
+++ b/binder-web-frontend/src/pages/home/components/tables-list/tables-list.component.scss
@@ -8,6 +8,10 @@
       }
       &-content {
         margin-left: 2rem;
+
+        &:hover {
+          cursor: pointer;
+        }
       }
     }
   }

--- a/binder-web-frontend/src/pages/home/components/tables-list/tables-list.component.ts
+++ b/binder-web-frontend/src/pages/home/components/tables-list/tables-list.component.ts
@@ -1,8 +1,25 @@
-import { Component } from '@angular/core';
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 
 @Component({
   selector: 'tables-list',
   templateUrl: './tables-list.component.html',
   styleUrls: ['./tables-list.component.scss'],
 })
-export class TablesListComponent {}
+export class TablesListComponent implements OnInit {
+  @Output() toDoListClickedEvent: EventEmitter<HTMLParagraphElement> =
+    new EventEmitter();
+  @Output() customListClickedEvent: EventEmitter<HTMLParagraphElement> =
+    new EventEmitter();
+
+  constructor() {}
+
+  ngOnInit() {}
+
+  onToDoListClicked() {
+    this.toDoListClickedEvent.emit();
+  }
+
+  onCustomListClicked() {
+    this.customListClickedEvent.emit();
+  }  
+}


### PR DESCRIPTION
## Summary

Table list elements are clickable now.

## Details

Table list elements: 
- **ToDo List**
- **Custom List**

are clickable and on hovering over elements cursor changes to pointer.

**Screenshots:**

![image](https://github.com/Strayker-Software/Binder/assets/80634023/bf711e42-00e1-4c8b-9633-d5ff3db6f33e)


## References

No external references needed.
