### PR TITLE
Make all controllers declarations unified

### DIFF
--- a/binder-web-backend/Binder.Api/Controllers/AppVersionsController.cs
+++ b/binder-web-backend/Binder.Api/Controllers/AppVersionsController.cs
@@ -3,7 +3,9 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Binder.Api.Controllers
 {
-    public sealed class AppVersionsController
+    [Route("api/versions")]
+    [ApiController]
+    public sealed class AppVersionsController : ControllerBase
     {
         private readonly IAppVersionService _service;
 
@@ -13,7 +15,6 @@ namespace Binder.Api.Controllers
         }
 
         [HttpGet]
-        [Route("GetVersion")]
         public ActionResult<string> Get()
         {
             return _service.GetAppVersion();

--- a/binder-web-backend/Binder.Api/Controllers/TablesController.cs
+++ b/binder-web-backend/Binder.Api/Controllers/TablesController.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Binder.Api.Controllers
 {
-    [Route("tables")]
+    [Route("api/tables")]
     [ApiController]
     public sealed class TablesController : ControllerBase
     {
@@ -15,8 +15,8 @@ namespace Binder.Api.Controllers
             _service = service;
         }
 
-        [HttpGet]
         [Route("{tableId}")]
+        [HttpGet]
         public ActionResult<DefaultTable> Get(int tableId)
         {
             return _service.GetTable(tableId);

--- a/binder-web-backend/Binder.Api/Controllers/ToDoTasksController.cs
+++ b/binder-web-backend/Binder.Api/Controllers/ToDoTasksController.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Binder.Api.Controllers
 {
-    [Route("tasks")]
+    [Route("api/tasks")]
     [ApiController]
     public sealed class ToDoTasksController : ControllerBase
     {

--- a/binder-web-frontend/src/api/api/appVersions.service.ts
+++ b/binder-web-frontend/src/api/api/appVersions.service.ts
@@ -93,10 +93,10 @@ export class AppVersionsService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getVersionGet(observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<string>;
-    public getVersionGet(observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpResponse<string>>;
-    public getVersionGet(observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpEvent<string>>;
-    public getVersionGet(observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<any> {
+    public apiVersionsGet(observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<string>;
+    public apiVersionsGet(observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpResponse<string>>;
+    public apiVersionsGet(observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpEvent<string>>;
+    public apiVersionsGet(observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<any> {
 
         let localVarHeaders = this.defaultHeaders;
 
@@ -131,7 +131,7 @@ export class AppVersionsService {
             }
         }
 
-        let localVarPath = `/GetVersion`;
+        let localVarPath = `/api/versions`;
         return this.httpClient.request<string>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,

--- a/binder-web-frontend/src/api/api/tables.service.ts
+++ b/binder-web-frontend/src/api/api/tables.service.ts
@@ -95,10 +95,10 @@ export class TablesService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public tablesGet(observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<Array<DefaultTable>>;
-    public tablesGet(observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpResponse<Array<DefaultTable>>>;
-    public tablesGet(observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpEvent<Array<DefaultTable>>>;
-    public tablesGet(observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<any> {
+    public apiTablesGet(observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<Array<DefaultTable>>;
+    public apiTablesGet(observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpResponse<Array<DefaultTable>>>;
+    public apiTablesGet(observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpEvent<Array<DefaultTable>>>;
+    public apiTablesGet(observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<any> {
 
         let localVarHeaders = this.defaultHeaders;
 
@@ -133,7 +133,7 @@ export class TablesService {
             }
         }
 
-        let localVarPath = `/tables`;
+        let localVarPath = `/api/tables`;
         return this.httpClient.request<Array<DefaultTable>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
@@ -151,12 +151,12 @@ export class TablesService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public tablesTableIdGet(tableId: number, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<DefaultTable>;
-    public tablesTableIdGet(tableId: number, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpResponse<DefaultTable>>;
-    public tablesTableIdGet(tableId: number, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpEvent<DefaultTable>>;
-    public tablesTableIdGet(tableId: number, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<any> {
+    public apiTablesTableIdGet(tableId: number, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<DefaultTable>;
+    public apiTablesTableIdGet(tableId: number, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpResponse<DefaultTable>>;
+    public apiTablesTableIdGet(tableId: number, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpEvent<DefaultTable>>;
+    public apiTablesTableIdGet(tableId: number, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<any> {
         if (tableId === null || tableId === undefined) {
-            throw new Error('Required parameter tableId was null or undefined when calling tablesTableIdGet.');
+            throw new Error('Required parameter tableId was null or undefined when calling apiTablesTableIdGet.');
         }
 
         let localVarHeaders = this.defaultHeaders;
@@ -192,7 +192,7 @@ export class TablesService {
             }
         }
 
-        let localVarPath = `/tables/${this.configuration.encodeParam({name: "tableId", value: tableId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int32"})}`;
+        let localVarPath = `/api/tables/${this.configuration.encodeParam({name: "tableId", value: tableId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int32"})}`;
         return this.httpClient.request<DefaultTable>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,

--- a/binder-web-frontend/src/api/api/toDoTasks.service.ts
+++ b/binder-web-frontend/src/api/api/toDoTasks.service.ts
@@ -96,10 +96,10 @@ export class ToDoTasksService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public tasksGet(tableId?: number, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<Array<ToDoTask>>;
-    public tasksGet(tableId?: number, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpResponse<Array<ToDoTask>>>;
-    public tasksGet(tableId?: number, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpEvent<Array<ToDoTask>>>;
-    public tasksGet(tableId?: number, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<any> {
+    public apiTasksGet(tableId?: number, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<Array<ToDoTask>>;
+    public apiTasksGet(tableId?: number, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpResponse<Array<ToDoTask>>>;
+    public apiTasksGet(tableId?: number, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpEvent<Array<ToDoTask>>>;
+    public apiTasksGet(tableId?: number, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<any> {
 
         let localVarQueryParameters = new HttpParams({encoder: this.encoder});
         if (tableId !== undefined && tableId !== null) {
@@ -140,7 +140,7 @@ export class ToDoTasksService {
             }
         }
 
-        let localVarPath = `/tasks`;
+        let localVarPath = `/api/tasks`;
         return this.httpClient.request<Array<ToDoTask>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,

--- a/binder-web-frontend/src/pages/home/components/header/header.component.ts
+++ b/binder-web-frontend/src/pages/home/components/header/header.component.ts
@@ -15,7 +15,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   
   ngOnInit(): void {
     this.appVersionsService
-      .getVersionGet()
+      .apiVersionsGet()
       .pipe(takeUntil(this.subscribe$))
       .subscribe({
         next: (ver: string) => 

--- a/binder-web-frontend/src/pages/home/components/table-view/table-view.component.ts
+++ b/binder-web-frontend/src/pages/home/components/table-view/table-view.component.ts
@@ -26,7 +26,7 @@ export class TableViewComponent implements OnInit, OnDestroy {
 
   getTasks() {
     this.toDoTasksService
-      .tasksGet(this.currentlySelectedTable.id)
+      .apiTasksGet(this.currentlySelectedTable.id)
       .pipe(takeUntil(this.subscribe$))
       .subscribe({
         next: (tasks: ToDoTask[]) => {

--- a/binder-web-frontend/src/pages/home/components/tables-list/tables-list.component.ts
+++ b/binder-web-frontend/src/pages/home/components/tables-list/tables-list.component.ts
@@ -16,7 +16,7 @@ export class TablesListComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.tableService
-      .tablesGet()
+      .apiTablesGet()
       .pipe(takeUntil(this.subscribe$))
       .subscribe({
         next: (tables: DefaultTable[]) => {


### PR DESCRIPTION
## Summary

Make all controller classes unified.

## Details

Make all controller classes unified to be:
- API Controllers,
- Inherit from ControllerBase class,
- Provide controller's route with REST API-compliant syntax,
- Regenerate frontend files after routing changes.

## References

No external references needed.
